### PR TITLE
New implementation for scrollTo()

### DIFF
--- a/fit4less-workout-booker.py
+++ b/fit4less-workout-booker.py
@@ -13,15 +13,12 @@ import datetime
 
 
 def scrollTo(driver, element):
-    '''
-    Prerequisite: The element MUST exist on webpage driver
-    '''
-    while True:
-        ActionChains(driver).send_keys(Keys.PAGE_DOWN).perform()
-        try:
-            return element
-        except:
-            continue
+    driver.execute_script("""arguments[0].scrollIntoView({
+            block: 'center',
+            inline: 'center'
+        });""", element)
+    return element
+
 
 class Account():
     '''
@@ -52,7 +49,7 @@ class Account():
         password.send_keys(self.getPassword())
 
         # Find login button, click
-        login_button = scrollTo(driver, driver.find_element_by_xpath('/html/body/div[2]/div/div/div/div/form/div[2]/div[1]/div'))
+        login_button = scrollTo(driver, driver.find_element_by_id('loginButton'))
         login_button.click()
 
         if driver.find_element_by_xpath('/html/body/div[2]/div/div/div/div/h1').text == 'LOG IN FAILED':
@@ -61,7 +58,7 @@ class Account():
         return 1
 
     def bookTime(self, driver):
-        alltimes_elements = driver.find_elements_by_xpath("(/html/body/div[5]/div/div/div/div/form/div[@class='available-slots'])[2]/div")
+        alltimes_elements = driver.find_elements_by_css_selector(".available-slots > .time-slot")
 
         if len(alltimes_elements) == 0:
             return 0


### PR DESCRIPTION
The previous implementation hit page down key, then returned

Sometimes the prior implementation would throw
selenium.common.exceptions.ElementClickInterceptedException
because the time slot was visually hidden behind the header or
footer even after this scroll attempt

The new implementation attempts to vertically center the element
in the middle of the viewport, hopefully ensuring the header and
footer don't impede clicking

Also replace a couple more xpaths with less complex selectors:
- #loginButton
- .available-slots > .time-slot